### PR TITLE
Allow use with Alchemy API, test hygiene

### DIFF
--- a/watson/bluemix_test.go
+++ b/watson/bluemix_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 )
 
+const VCAPKEY = "VCAP_SERVICES"
+
 var vcapTests = []struct {
 	vcap_services string
 	service_name  string
@@ -74,8 +76,9 @@ var vcapTests = []struct {
 }
 
 func TestGetCredentials(t *testing.T) {
+	oldVcapServices := os.Getenv(VCAPKEY)
 	for i := range vcapTests {
-		os.Setenv("VCAP_SERVICES", vcapTests[i].vcap_services)
+		os.Setenv(VCAPKEY, vcapTests[i].vcap_services)
 		creds, err := getBluemixCredentials(vcapTests[i].service_name, vcapTests[i].service_plan)
 		if (err != nil && vcapTests[i].err == nil) || (err == nil && vcapTests[i].err != nil) {
 			t.Errorf("credentials test %d:\nVCAP_SERVICES = %s\ngot error %#v\nwanted %#v\n", i, vcapTests[i].vcap_services, err, vcapTests[i].err)
@@ -91,5 +94,10 @@ func TestGetCredentials(t *testing.T) {
 			t.Errorf("credentials test %d:\nVCAP_SERVICES = %s\ngot %#v\nwanted %#v\n", i, vcapTests[i].vcap_services, creds, vcapTests[i].want)
 			return
 		}
+	}
+	if oldVcapServices != "" {
+		os.Setenv(VCAPKEY, oldVcapServices)
+	} else {
+		os.Unsetenv(VCAPKEY)
 	}
 }

--- a/watson/request_test.go
+++ b/watson/request_test.go
@@ -1,0 +1,71 @@
+package watson
+
+import (
+	"testing"
+)
+
+func TestMissingUrl(t *testing.T) {
+	creds := Credentials{
+		Url:      "",
+		Username: "foo",
+		Password: "foo",
+	}
+	_, err := NewClient(creds)
+	if err == nil {
+		t.Error("Expected client creation to fail")
+	}
+}
+
+func TestMissingUsername(t *testing.T) {
+	creds := Credentials{
+		Url:      "foo",
+		Username: "",
+		Password: "foo",
+	}
+	_, err := NewClient(creds)
+	if err == nil {
+		t.Error("Expected client creation to fail")
+	}
+}
+
+func TestMissingPassword(t *testing.T) {
+	creds := Credentials{
+		Url:      "foo",
+		Username: "foo",
+		Password: "",
+	}
+	_, err := NewClient(creds)
+	if err == nil {
+		t.Error("Expected client creation to fail")
+	}
+}
+
+func TestAllOk(t *testing.T) {
+	creds := Credentials{
+		Url:      "foo",
+		Username: "foo",
+		Password: "foo",
+	}
+	client, err := NewClient(creds)
+	if err != nil {
+		t.Error("Expected client creation to succeed")
+	}
+
+	if client.Creds != creds {
+		t.Error("Credentials do not match")
+	}
+}
+
+func TestApiKeySufficient(t *testing.T) {
+	creds := Credentials{
+		ApiKey: "foo",
+	}
+	client, err := NewClient(creds)
+	if err != nil {
+		t.Error("Expected client creation to succeed")
+	}
+
+	if client.Creds != creds {
+		t.Error("Credentials do not match")
+	}
+}


### PR DESCRIPTION
This PR allows the use of `go-watson-sdk` with the AlchemyAPI, which can be authenticated against using only an API Key. Previously, such a client configuration would be rejected because a username and password was not present.

This patch adds tests for the existing client behaviour, as well as extending the validation to allow just an API key.

This patch also fixes a small bug with the existing tests, which would set the `VCAP_SERVICES` environment variable and never unset it, causing other tests (in the case, the ones added to test API key behaviour!) to fail unexpectedly.
