### PR TITLE
added support for custom models

### DIFF
--- a/watson/speech_to_text/speech_to_text.go
+++ b/watson/speech_to_text/speech_to_text.go
@@ -172,7 +172,7 @@ type StateReply struct {
 // audio data. Upon the generation of a transcription event, an 'Event' object is pushed into the output channel.
 // 'options' can contain options to be send in the stream initialization; more information available at:
 // http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/speech-to-text/websockets.shtml#WSstart
-func (c Client) NewStream(model string, content_type string, options map[string]interface{}) (<-chan Event, io.WriteCloser, error) {
+func (c Client) NewStream(model string, customization_id string, content_type string, options map[string]interface{}) (<-chan Event, io.WriteCloser, error) {
 	token, err := authorization.GetToken(c.watsonClient.Creds)
 	if err != nil {
 		return nil, nil, errors.New("failed to acquire auth token: " + err.Error())
@@ -186,6 +186,9 @@ func (c Client) NewStream(model string, content_type string, options map[string]
 	q.Set("watson-token", token)
 	if len(model) > 0 {
 		q.Set("model", model)
+	}
+	if len(customization_id) > 0 {
+		q.Set("customization_id", customization_id)
 	}
 	u.RawQuery = q.Encode()
 	u.Path += c.version + "/recognize"

--- a/watson/speech_to_text/speech_to_text_test.go
+++ b/watson/speech_to_text/speech_to_text_test.go
@@ -57,7 +57,7 @@ func TestStream(t *testing.T) {
 		t.Errorf("NewClient() failed %#v\n", err)
 		return
 	}
-	output, stream, err := c.NewStream("", "audio/wav", map[string]interface{}{"continuous": true, "interim_results": false, "timestamps": false})
+	output, stream, err := c.NewStream("", "", "audio/wav", map[string]interface{}{"continuous": true, "interim_results": false, "timestamps": false})
 	if err != nil {
 		t.Errorf("NewStream() failed %#v %s\n", err, err.Error())
 		return


### PR DESCRIPTION
Added support for custom models - they require a customization_id value to be added to the connection url. 

A sample of how they were used in my code is shown below. 
```go
	file := strings.ToLower(e)
	encoding := ""
	model := ""
	customization_id := ""

	if strings.Contains(file, "mulaw") {
		encoding = "audio/mulaw;rate=8000"
		model = "en-US_NarrowbandModel"
		customization_id = "802d10d0-80c1-11e7-83e1-49cd271ae6a2"
	} else if strings.Contains(file, "linear16") {
		encoding = "audio/wav"
		model = "en-US_BroadbandModel"
		customization_id = "42f6e650-80c1-11e7-83e1-49cd271ae6a2"
	} else if strings.Contains(file, "flac") {
		encoding = "audio/flac"
		model = "en-US_BroadbandModel"
		customization_id = "42f6e650-80c1-11e7-83e1-49cd271ae6a2"
	} else {
		continue
	}

	evt, writer, err := client.NewStream(model, customization_id, encoding, make(map[string]interface{}))
```
