### PR TITLE
Forward the content_type that is passed to Convert() to the Watson API

### DIFF
--- a/watson/document_conversion/document_conversion.go
+++ b/watson/document_conversion/document_conversion.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 
 	"github.com/liviosoares/go-watson-sdk/watson"
 )
@@ -73,7 +74,10 @@ func (c Client) Convert(conversion_target string, config_options map[string]inte
 	w := multipart.NewWriter(buf)
 	w.WriteField("config", string(config_json))
 	// write the file out
-	part, err := w.CreateFormFile("file", "file")
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Disposition", `form-data; name="file"; filename="file"`)
+	h.Set("Content-Type", content_type)
+	part, err := w.CreatePart(h)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The API seems capable of detecting the content type itself, but is forced to do so every time, since `w.CreateFormFile()` sets the content type to `application/octet-stream`.

This broke the msword conversion for me, as my actual Mime-type was something like `application/x-tika-msword` and not `application/msword`.

With this change the `content_type` you send in to `Convert()` is actually passed to the Watson API.